### PR TITLE
debian/changelog - fix its format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-midicvt-0.2 (0.2.0) unstable; urgency=low
+midicvt (0.2.0) unstable; urgency=low
 
   * Initial Release.
 


### PR DESCRIPTION
The expected format from dpkg is "packagename (version)", not
"packagename-version (version)".
